### PR TITLE
Update bokeh.yaml for new api

### DIFF
--- a/kubernetes/bokeh.yaml
+++ b/kubernetes/bokeh.yaml
@@ -9,13 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bokeh
 spec:
   replicas: 2
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      run: bokeh
   template:
     metadata:
       labels:


### PR DESCRIPTION
The API has been updated and needs to reflect the new api (extensions/v1beta1 to apps/v1) and the selector must now be included in the deployment